### PR TITLE
Remove registerWith which has been long deprecated.

### DIFF
--- a/android/src/main/kotlin/org/jezequel/secure_application/SecureApplicationPlugin.kt
+++ b/android/src/main/kotlin/org/jezequel/secure_application/SecureApplicationPlugin.kt
@@ -8,7 +8,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 import android.view.WindowManager.LayoutParams;
 import androidx.lifecycle.Lifecycle
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
@@ -59,23 +58,6 @@ public class SecureApplicationPlugin: FlutterPlugin, MethodCallHandler, Activity
   @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
   fun connectListener() {
     // not used for now but might be used to add some features in the future
-  }
-
-  // This static function is optional and equivalent to onAttachedToEngine. It supports the old
-  // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
-  // plugin registration via this function while apps migrate to use the new Android APIs
-  // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
-  //
-  // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
-  // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
-  // depending on the user's project. onAttachedToEngine or registerWith must both be defined
-  // in the same class.
-  companion object {
-    @JvmStatic
-    fun registerWith(registrar: Registrar) {
-      val channel = MethodChannel(registrar.messenger(), "secure_application")
-      channel.setMethodCallHandler(SecureApplicationPlugin())
-    }
   }
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {


### PR DESCRIPTION
This was removed from Flutter 3.29 so this method causes the plugin to no longer build.